### PR TITLE
Add configuration for the job queue

### DIFF
--- a/app/jobs/solidus_importer/import_job.rb
+++ b/app/jobs/solidus_importer/import_job.rb
@@ -2,7 +2,7 @@
 
 module SolidusImporter
   class ImportJob < ApplicationJob
-    queue_as :default
+    queue_as { SolidusImporter.configuration.processing_queue }
 
     retry_on ActiveRecord::Deadlocked
 

--- a/app/jobs/solidus_importer/process_row_group_job.rb
+++ b/app/jobs/solidus_importer/process_row_group_job.rb
@@ -2,7 +2,7 @@
 
 module SolidusImporter
   class ProcessRowGroupJob < ApplicationJob
-    queue_as :default
+    queue_as { SolidusImporter.configuration.processing_queue }
 
     def perform(import_id, row_ids)
       import = SolidusImporter::Import.find(import_id)

--- a/lib/solidus_importer/configuration.rb
+++ b/lib/solidus_importer/configuration.rb
@@ -2,6 +2,8 @@
 
 module SolidusImporter
   class Configuration < Spree::Preferences::Configuration
+    attr_writer :processing_queue
+
     preference :solidus_importer, :hash, default: {
       customers: {
         importer: SolidusImporter::BaseImporter,
@@ -41,6 +43,10 @@ module SolidusImporter
 
     def available_types
       solidus_importer.keys
+    end
+
+    def processing_queue
+      @processing_queue ||= :default
     end
   end
 


### PR DESCRIPTION
This adds a configuration to specify the queue that will be used to process importer jobs.  If the configuration is not specified, it will use the `default` queue.

The queue name can be specified in the initializer:
```
SolidusImporter.configure do |config|
  config.processing_queue = :importer
end
``` 

[Ticket](https://app.asana.com/0/1201736950492870/1203297093202043)